### PR TITLE
provider: update for v12

### DIFF
--- a/invenio_dnb_urn/provider/dnburn.py
+++ b/invenio_dnb_urn/provider/dnburn.py
@@ -103,6 +103,11 @@ class DnbUrnProvider(PIDProvider):
         # Delegate to client
         return self.client.generate_urn(record)
 
+    @classmethod
+    def is_enabled(cls, app):
+        """Determine if dnb provider is enabled or not."""
+        return True
+
     def can_modify(self, pid, **kwargs):
         """Checks if the PID can be modified."""
         return not pid.is_registered() and not pid.is_reserved()


### PR DESCRIPTION
I've added an `is_enabled` method following https://github.com/inveniosoftware/invenio-rdm-records/pull/1740/files. This is required for the latest v12 version to work. You'll also need to modify invenio.cfg with

```
RDM_PERSISTENT_IDENTIFIERS = {
  ...
+   "urn": {
+     "providers": ["urn"],
+     "required": True,
+     "label": _("URN"),
+     "is_enabled": providers.DnbUrnProvider.is_enabled,
+   },
  ...
}
```

I've added this to the docs with https://github.com/inveniosoftware/docs-invenio-rdm/pull/665

I don't have URN access, so please test befoe accepting.